### PR TITLE
Removes bad link to getgood.at in docs/en

### DIFF
--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -55,7 +55,6 @@ Most notably however, there are two main shards that are responsible for the gre
 - [crystal-koans](https://github.com/ilmanzo/crystal-koans) - Learn Crystal by writing unit tests
 - [crystal-lang.org](https://crystal-lang.org) - Official language site
 - [devdocs.io](https://devdocs.io/crystal/) - API Documentation Browser with Crystal support
-- [getgood.at](https://getgood.at/in-a-day/crystal) - Learn Crystal in a Day
 - [Programming Crystal](https://pragprog.com/book/crystal/programming-crystal) - PragProg book to start your Crystal journey
 
 ::: info


### PR DESCRIPTION
This PR removes the link on the main index page under "New To Crystal" for `getgood.at/crystal` has a bad SSL cert or none, and when proceeding to the domain the `/crystal` route returns a 404 error page.